### PR TITLE
modify python_requires to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         "pyyaml==5.4"
     ],
 
-    python_requires=">=3.8",
+    python_requires=">=3.7",
 
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
*Issue #, if available:* python version issue on setup.py

*Description of changes:*
I did a spin up a test and CDK didn't work because of the  the below reason.

ERROR: Package 'emr-roadshow' requires a different Python: 3.7.16 not in '>=3.8'